### PR TITLE
Add US market summary support

### DIFF
--- a/myapi/containers.py
+++ b/myapi/containers.py
@@ -105,6 +105,7 @@ class Container(containers.DeclarativeContainer):
             "myapi.routers.futures_router",
             "myapi.routers.signal_router",
             "myapi.routers.ticker_router",
+            "myapi.routers.market_router",
         ],
     )
 

--- a/myapi/domain/market/__init__.py
+++ b/myapi/domain/market/__init__.py
@@ -1,0 +1,8 @@
+from .market_schema import WebSearchMarketItem, WebSearchMarketResponse
+from .market_models import WebSearchResult
+
+__all__ = [
+    "WebSearchMarketItem",
+    "WebSearchMarketResponse",
+    "WebSearchResult",
+]

--- a/myapi/domain/market/market_models.py
+++ b/myapi/domain/market/market_models.py
@@ -1,0 +1,19 @@
+from sqlalchemy import Column, Integer, String, DateTime, func
+
+from myapi.database import Base
+
+
+class WebSearchResult(Base):
+    """Universal table for storing web search results for tickers and market."""
+
+    __tablename__ = "web_search_results"
+    __table_args__ = {"schema": "crypto"}
+
+    id = Column(Integer, primary_key=True, index=True)
+    result_type = Column(String, nullable=False)  # e.g., 'market' or 'ticker'
+    ticker = Column(String, nullable=True)
+    date_YYYYMMDD = Column(String, nullable=False)
+    headline = Column(String, nullable=True)
+    summary = Column(String, nullable=True)
+    detail_description = Column(String, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/myapi/domain/market/market_schema.py
+++ b/myapi/domain/market/market_schema.py
@@ -1,0 +1,13 @@
+from typing import List
+from pydantic import BaseModel
+
+
+class WebSearchMarketItem(BaseModel):
+    date_YYYYMMDD: str
+    headline: str
+    summary: str
+    detail_description: str
+
+
+class WebSearchMarketResponse(BaseModel):
+    search_results: List[WebSearchMarketItem]

--- a/myapi/main.py
+++ b/myapi/main.py
@@ -16,6 +16,7 @@ from myapi.routers import (
     kakao_router,
     signal_router,
     trading_router,
+    market_router,
 )
 from myapi.utils.config import init_logging
 
@@ -107,4 +108,5 @@ app.include_router(coinone_router.router)
 app.include_router(futures_router.router)
 app.include_router(signal_router.router)
 app.include_router(ticker_router.router)
+app.include_router(market_router.router)
 handler = Mangum(app)

--- a/myapi/routers/market_router.py
+++ b/myapi/routers/market_router.py
@@ -1,0 +1,20 @@
+from datetime import date
+from fastapi import APIRouter, Depends
+from dependency_injector.wiring import inject, Provide
+
+from myapi.containers import Container
+from myapi.domain.market.market_schema import WebSearchMarketResponse
+from myapi.services.signal_service import SignalService
+from myapi.services.ai_service import AIService
+
+router = APIRouter(prefix="/market", tags=["market"])
+
+
+@router.get("/news-summary", response_model=WebSearchMarketResponse)
+@inject
+def market_news_summary(
+    signal_service: SignalService = Depends(Provide[Container.services.signal_service]),
+    ai_service: AIService = Depends(Provide[Container.services.ai_service]),
+) -> WebSearchMarketResponse | str:
+    today_str = date.today().strftime("%Y-%m-%d")
+    return signal_service.get_us_market_info(today_str, ai_service=ai_service)

--- a/myapi/services/signal_service.py
+++ b/myapi/services/signal_service.py
@@ -27,6 +27,7 @@ from myapi.domain.signal.signal_schema import (
     FundamentalData,
     NewsHeadline,
 )
+from myapi.domain.market.market_schema import WebSearchMarketResponse
 
 logger = logging.getLogger(__name__)
 
@@ -1275,3 +1276,36 @@ class SignalService:
         ╰─ END PROTOCOL
         """
         return prompt
+
+    def generate_us_market_prompt(self, date: str) -> str:
+        """Generate a prompt to summarize U.S. market catalysts."""
+        prompt = f"""
+        today is {date} and you are an AI assistant for U.S. market analysis.
+        Summarize key news, economic data releases, index movements and any other events
+        driving the U.S. stock market.
+
+        ╭─ TASK
+        │ 1. Search the open web for the most important U.S. market catalysts.
+        │    • Economic releases (CPI, jobs, FOMC, etc.) around the given date.
+        │    • Headlines impacting overall market sentiment.
+        │    • Movements in major indexes (S&P 500, NASDAQ, Dow) and notable sectors.
+        │ 2. Provide up to 5 concise bullet points summarizing the findings.
+        ╰─ END TASK
+
+        ╭─ SEARCH PROTOCOL
+        │ • Use Google Search with recency around {date} to gather information.
+        │ • Return "NO DATA" if nothing relevant is found.
+        ╰─ END PROTOCOL
+        """
+        return prompt
+
+    def get_us_market_info(
+        self,
+        date: str,
+        ai_service: "AIService",
+    ) -> WebSearchMarketResponse | str:
+        prompt = self.generate_us_market_prompt(date)
+        return ai_service.gemini_search_grounding(
+            prompt=prompt,
+            schema=WebSearchMarketResponse,
+        )


### PR DESCRIPTION
## Summary
- create `WebSearchMarketItem` and `WebSearchMarketResponse` schemas
- add universal `WebSearchResult` ORM table
- implement market news prompt and retrieval in `SignalService`
- expose new endpoint `/market/news-summary`
- register router and dependency wiring

## Testing
- `python -m py_compile myapi/domain/market/market_schema.py myapi/domain/market/market_models.py myapi/routers/market_router.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bcc9c1a108328a858acac27049fee