### PR TITLE
Enhance market prompt and persist web search data

### DIFF
--- a/myapi/containers.py
+++ b/myapi/containers.py
@@ -6,6 +6,7 @@ from myapi.repositories.futures_repository import FuturesRepository
 from myapi.repositories.signals_repository import SignalsRepository
 from myapi.repositories.trading_repository import TradingRepository
 from myapi.repositories.ticker_repository import TickerRepository
+from myapi.repositories.web_search_repository import WebSearchResultRepository
 from myapi.services import futures_service
 from myapi.services.ai_service import AIService
 from myapi.services.aws_service import AwsService
@@ -35,6 +36,9 @@ class RepositoryModule(containers.DeclarativeContainer):
     trading_repository = providers.Factory(TradingRepository, db_session=get_db)
     futures_repository = providers.Factory(FuturesRepository, db_session=get_db)
     ticker_repository = providers.Factory(TickerRepository, db_session=get_db)
+    web_search_repository = providers.Factory(
+        WebSearchResultRepository, db_session=get_db
+    )
 
 
 class ServiceModule(containers.DeclarativeContainer):
@@ -79,6 +83,7 @@ class ServiceModule(containers.DeclarativeContainer):
     signal_service = providers.Factory(
         SignalService,
         signals_repository=repositories.signals_repository,
+        web_search_repository=repositories.web_search_repository,
         settings=config.config,
     )
     ticker_service = providers.Factory(

--- a/myapi/repositories/web_search_repository.py
+++ b/myapi/repositories/web_search_repository.py
@@ -1,0 +1,14 @@
+from typing import List, Optional
+from sqlalchemy.orm import Session
+
+from myapi.domain.market.market_models import WebSearchResult
+
+
+class WebSearchResultRepository:
+    def __init__(self, db_session: Session):
+        self.db_session = db_session
+
+    def bulk_create(self, records: List[WebSearchResult]) -> List[WebSearchResult]:
+        self.db_session.bulk_save_objects(records)
+        self.db_session.commit()
+        return records

--- a/myapi/routers/market_router.py
+++ b/myapi/routers/market_router.py
@@ -17,4 +17,10 @@ def market_news_summary(
     ai_service: AIService = Depends(Provide[Container.services.ai_service]),
 ) -> WebSearchMarketResponse | str:
     today_str = date.today().strftime("%Y-%m-%d")
-    return signal_service.get_us_market_info(today_str, ai_service=ai_service)
+    result = signal_service.get_us_market_info(today_str, ai_service=ai_service)
+    if isinstance(result, WebSearchMarketResponse):
+        signal_service.save_web_search_results(
+            result_type="market",
+            results=result.search_results,
+        )
+    return result

--- a/myapi/routers/signal_router.py
+++ b/myapi/routers/signal_router.py
@@ -175,6 +175,12 @@ def llm_query(
             ),
             schema=WebSearchTickerResponse,
         )
+        if web_search_gemini_result:
+            signal_service.save_web_search_results(
+                result_type="ticker",
+                results=web_search_gemini_result.search_results,
+                ticker=req.ticker,
+            )
         if req.additional_info and web_search_gemini_result:
             req.additional_info = (
                 req.additional_info

--- a/myapi/services/signal_service.py
+++ b/myapi/services/signal_service.py
@@ -14,10 +14,12 @@ import yfinance as yf
 import pandas_ta as ta
 import requests
 import datetime as dt
+from pydantic import BaseModel
 
 from pandas_datareader import data as pdr
 
 from myapi.repositories.signals_repository import SignalsRepository
+from myapi.repositories.web_search_repository import WebSearchResultRepository
 from myapi.utils.config import Settings
 from myapi.domain.signal.signal_schema import (
     Article,
@@ -28,6 +30,7 @@ from myapi.domain.signal.signal_schema import (
     NewsHeadline,
 )
 from myapi.domain.market.market_schema import WebSearchMarketResponse
+from myapi.domain.market.market_models import WebSearchResult
 
 logger = logging.getLogger(__name__)
 
@@ -80,12 +83,38 @@ def flatten_price_columns(df: pd.DataFrame, ticker: str | None = None) -> pd.Dat
 
 
 class SignalService:
-    def __init__(self, settings: Settings, signals_repository: SignalsRepository):
+    def __init__(
+        self,
+        settings: Settings,
+        signals_repository: SignalsRepository,
+        web_search_repository: "WebSearchResultRepository",
+    ):
         self.settings = settings
         self.DEFAULT_UNIVERSE: str = "SPY,QQQ,AAPL,MSFT,TSLA"
         self.START_DAYS_BACK: int = 365
         self.signals_repository = signals_repository
+        self.web_search_repository = web_search_repository
         # self.sia = SentimentIntensityAnalyzer()
+
+    def save_web_search_results(
+        self,
+        result_type: str,
+        results: List[BaseModel],
+        ticker: str | None = None,
+    ) -> None:
+        db_items = [
+            WebSearchResult(
+                result_type=result_type,
+                ticker=ticker,
+                date_YYYYMMDD=item.date_YYYYMMDD,
+                headline=getattr(item, "headline", None),
+                summary=getattr(item, "summary", None),
+                detail_description=getattr(item, "detail_description", None),
+            )
+            for item in results
+        ]
+        if db_items:
+            self.web_search_repository.bulk_create(db_items)
 
     def market_ok(self, index_ticker="SPY") -> bool:
         """시장 필터: 지수 종가가 20일 SMA 위면 True"""
@@ -1282,14 +1311,15 @@ class SignalService:
         prompt = f"""
         today is {date} and you are an AI assistant for U.S. market analysis.
         Summarize key news, economic data releases, index movements and any other events
-        driving the U.S. stock market.
+        driving the U.S. stock market. Focus on actionable catalysts investors care about.
 
         ╭─ TASK
         │ 1. Search the open web for the most important U.S. market catalysts.
         │    • Economic releases (CPI, jobs, FOMC, etc.) around the given date.
         │    • Headlines impacting overall market sentiment.
         │    • Movements in major indexes (S&P 500, NASDAQ, Dow) and notable sectors.
-        │ 2. Provide up to 5 concise bullet points summarizing the findings.
+        │ 2. Provide 3-5 concise bullet points summarizing the findings.
+        │    • Include closing levels or percentage moves for the major indices if available.
         ╰─ END TASK
 
         ╭─ SEARCH PROTOCOL


### PR DESCRIPTION
## Summary
- tweak US market news prompt to deliver more actionable info
- store market and ticker web search results in `web_search_results`
- wire up new `WebSearchResultRepository`

## Testing
- `python -m py_compile myapi/repositories/web_search_repository.py myapi/routers/market_router.py myapi/routers/signal_router.py myapi/containers.py`
- `python -m py_compile myapi/services/signal_service.py` *(fails: f-string expression part cannot include a backslash)*

------
https://chatgpt.com/codex/tasks/task_e_684bd153c45c8328a6c408ffec7893ee