### PR TITLE
Add relative strength indicators

### DIFF
--- a/myapi/domain/ai/const.py
+++ b/myapi/domain/ai/const.py
@@ -81,7 +81,7 @@ def generate_prompt(
     - orderbook_data: {orderbook_data}
     - arbitrage_signal: {arbitrage_signal}
     - trade_history: {trade_history}
-    - current_active_orders: {"\n".join([order.description for order in current_active_orders]) if current_active_orders else "None"}
+    - current_active_orders: {chr(10).join([order.description for order in current_active_orders]) if current_active_orders else "None"}
 
     ### 3. Additional Context
     - additional_context: {additional_context}

--- a/myapi/domain/signal/signal_schema.py
+++ b/myapi/domain/signal/signal_schema.py
@@ -22,6 +22,8 @@ Strategy = Literal[
     "QUIET_PULLBACK",
     "VOLATILITY_COMPRESSION",
     "VCP_DAILY",
+    "RS_SHORT",
+    "RS_MID",
 ]
 
 DefaultStrategies: List[Strategy] = [
@@ -44,6 +46,8 @@ DefaultStrategies: List[Strategy] = [
     "QUIET_PULLBACK",
     "VOLATILITY_COMPRESSION",
     "VCP_DAILY",
+    "RS_SHORT",
+    "RS_MID",
 ]
 
 DefaultTickers = [

--- a/myapi/routers/signal_router.py
+++ b/myapi/routers/signal_router.py
@@ -289,7 +289,7 @@ async def get_signals(
         if df is None or df.empty:
             continue
 
-        df = signal_service.add_indicators(df)
+        df = signal_service.add_indicators(df, ticker=t)
 
         if t == "SPY":
             spy_persentage_from_200ma = (


### PR DESCRIPTION
## Summary
- add RS_SHORT and RS_MID strategies
- compute relative strength vs SPY in `add_computed_rs_data`
- expose RS indicators through `add_indicators`
- trigger new RS strategies during evaluation
- fix f-string backslash issues

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fa151e06c83288a341e7b21ada4ac