### PR TITLE
Add weekly action and price movement APIs

### DIFF
--- a/myapi/routers/signal_router.py
+++ b/myapi/routers/signal_router.py
@@ -456,6 +456,22 @@ async def get_today_signals_by_ticker(
     return ticker_signals
 
 
+@router.get("/weekly-action-count")
+@inject
+async def get_weekly_action_count(
+    tickers: str = "",
+    reference_date: date = date.today(),
+    action: Literal["buy", "sell"] = "buy",
+    db_signal_service: DBSignalService = Depends(
+        Provide[Container.services.db_signal_service]
+    ),
+):
+    """지정한 날짜 기준 일주일간 액션별 시그널 개수를 조회합니다."""
+
+    ticker_list = [t.strip().upper() for t in tickers.split(",") if t] if tickers else None
+    return await db_signal_service.get_weekly_action_counts(ticker_list, reference_date, action)
+
+
 @router.get("/date")
 @inject
 async def get_signal_by_date(

--- a/myapi/routers/ticker_router.py
+++ b/myapi/routers/ticker_router.py
@@ -1,6 +1,6 @@
 import datetime
 from fastapi import APIRouter, Depends, HTTPException, Query
-from typing import List
+from typing import List, Literal
 from datetime import date, timedelta
 
 from dependency_injector.wiring import inject, Provide
@@ -253,3 +253,20 @@ def get_signal_accuracy(
         raise HTTPException(
             status_code=500, detail=f"시그널 정확도 조회 중 오류 발생: {str(e)}"
         )
+
+
+@router.get("/weekly-price-movement")
+@inject
+def get_weekly_price_movement(
+    tickers: str = "",
+    reference_date: date = date.today(),
+    direction: Literal["up", "down"] = "up",
+    ticker_service: TickerService = Depends(Provide[Container.services.ticker_service]),
+):
+    """일주일간 가격이 상승하거나 하락한 횟수를 조회합니다."""
+
+    ticker_list = [t.strip().upper() for t in tickers.split(",") if t] if tickers else None
+    end_dt = reference_date
+    start_dt = end_dt - timedelta(days=7)
+
+    return ticker_service.count_price_movements(ticker_list, start_dt, end_dt, direction)

--- a/myapi/services/db_signal_service.py
+++ b/myapi/services/db_signal_service.py
@@ -403,3 +403,25 @@ class DBSignalService:
                 f"Error getting signals for {ticker} on {date_value}: {e}"
             )
             return []
+
+    async def get_weekly_action_counts(
+        self,
+        tickers: Optional[List[str]],
+        reference_date: date,
+        action: str,
+    ) -> List[Dict[str, int]]:
+        """지정한 날짜를 기준으로 일주일간 액션별 시그널 개수를 조회합니다."""
+
+        try:
+            if action not in ["buy", "sell"]:
+                raise HTTPException(status_code=400, detail="Action must be 'buy' or 'sell'")
+
+            end_dt = datetime.combine(reference_date, datetime.max.time())
+            start_dt = end_dt - timedelta(days=7)
+
+            return self.repository.count_signals_by_action(tickers, start_dt, end_dt, action)
+        except HTTPException as e:
+            raise e
+        except Exception as e:
+            self.logger.error(f"Error fetching weekly action counts: {e}")
+            raise HTTPException(status_code=500, detail=f"Failed to fetch action counts: {e}")

--- a/myapi/services/ticker_service.py
+++ b/myapi/services/ticker_service.py
@@ -424,3 +424,13 @@ class TickerService:
         """
         tickers = self.ticker_repository.get_all_ticker_name()
         return tickers
+
+    def count_price_movements(
+        self,
+        symbols: Optional[List[str]],
+        start_date: date,
+        end_date: date,
+        direction: str,
+    ) -> List[Dict[str, int]]:
+        """기간 동안 가격 상승/하락 횟수를 반환합니다."""
+        return self.ticker_repository.count_price_movements(symbols, start_date, end_date, direction)


### PR DESCRIPTION
## Summary
- support counting signals by action in the repository
- expose service helper to compute weekly action counts
- provide API endpoints for weekly signal counts and price movements
- support counting price movement changes for tickers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852b13df72083289c415ad4d9b1af09