### PR TITLE
Add date validation utility

### DIFF
--- a/myapi/routers/news_router.py
+++ b/myapi/routers/news_router.py
@@ -1,5 +1,7 @@
 from datetime import date
 from typing import Literal, Optional
+
+from myapi.utils.date_utils import validate_date
 from fastapi import APIRouter, Depends
 from dependency_injector.wiring import inject, Provide
 
@@ -22,7 +24,7 @@ def get_news(
     news_date: Optional[date] = date.today(),
     signal_service: SignalService = Depends(Provide[Container.services.signal_service]),
 ):
-    today_str = date.today() if news_date is None else news_date
+    today_str = validate_date(news_date if news_date else date.today())
     result = signal_service.get_web_search_summary(
         type=news_type,
         ticker=ticker,
@@ -39,11 +41,12 @@ def news_recommendations(
     date: Optional[date] = date.today(),
     signal_service: SignalService = Depends(Provide[Container.services.signal_service]),
 ):
+    valid_date = validate_date(date if date else date.today())
     return {
         "results": signal_service.get_ticker_news_by_recommendation(
             recommendation=recommendation,
             limit=limit,
-            date=date,
+            date=valid_date,
         )
     }
 
@@ -77,5 +80,6 @@ def market_forecast(
         Provide[Container.services.websearch_service]
     ),
 ):
+    forecast_date = validate_date(forecast_date)
 
     return websearch_service.forecast_market(forecast_date, source=source)

--- a/myapi/routers/signal_router.py
+++ b/myapi/routers/signal_router.py
@@ -6,6 +6,8 @@ from venv import logger
 from fastapi import APIRouter, Depends
 from datetime import date, timedelta
 
+from myapi.utils.date_utils import validate_date
+
 from dependency_injector.wiring import inject, Provide
 from pandas import DataFrame
 
@@ -481,7 +483,7 @@ async def get_weekly_action_count(
         else DefaultTickers
     )
 
-    reference_date = reference_date if reference_date else date.today()
+    reference_date = validate_date(reference_date if reference_date else date.today())
 
     result = await db_signal_service.get_weekly_action_counts(
         ticker_list, reference_date, action
@@ -507,6 +509,7 @@ async def get_signal_by_date(
     symbol_list = symbols.split(",") if symbols else []
 
     date_value = datetime.datetime.strptime(date, "%Y-%m-%d").date()
+    validate_date(date_value)
     response = await db_signal_service.get_signals_result(
         date=date_value, symbols=symbol_list
     )

--- a/myapi/routers/ticker_router.py
+++ b/myapi/routers/ticker_router.py
@@ -3,6 +3,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from typing import List, Literal, Optional
 from datetime import date, timedelta
 
+from myapi.utils.date_utils import validate_date
+
 from dependency_injector.wiring import inject, Provide
 
 from myapi.containers import Container
@@ -71,7 +73,7 @@ def get_ticker_by_date(
     date: date = Query(..., description="조회할 날짜"),
     ticker_service: TickerService = Depends(Provide[Container.services.ticker_service]),
 ):
-    # date_obj = datetime.date.fromisoformat(date)  # 문자열을 date 객체로 변환
+    validate_date(date)
     ticker = ticker_service.get_ticker_by_date(symbol, date)
     if ticker is None:
         raise HTTPException(
@@ -271,7 +273,7 @@ def get_weekly_price_movement(
         else DefaultTickers
     )
 
-    end_dt = reference_date if reference_date else date.today()
+    end_dt = validate_date(reference_date if reference_date else date.today())
     start_dt = end_dt - timedelta(days=7)
 
     tickers_with_count = ticker_service.count_price_movements(

--- a/myapi/utils/date_utils.py
+++ b/myapi/utils/date_utils.py
@@ -1,0 +1,26 @@
+from datetime import date, timedelta
+from fastapi import HTTPException
+
+
+def validate_date(input_date: date, max_past_days: int = 30) -> date:
+    """Validate a date is not in the future and not too far in the past.
+
+    Args:
+        input_date: The date to validate.
+        max_past_days: Maximum number of days in the past allowed.
+
+    Returns:
+        The validated date.
+
+    Raises:
+        HTTPException: If the date is in the future or too far in the past.
+    """
+    today = date.today()
+    if input_date > today:
+        raise HTTPException(status_code=400, detail="Date cannot be in the future.")
+    if input_date < today - timedelta(days=max_past_days):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Date cannot be older than {max_past_days} days.",
+        )
+    return input_date


### PR DESCRIPTION
## Summary
- add a reusable `validate_date` util
- enforce date validation in signal, ticker and news routers

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6857803730708328840fc7d3fab2b255