### PR TITLE
Implement bearer token authentication

### DIFF
--- a/myapi/containers.py
+++ b/myapi/containers.py
@@ -71,6 +71,7 @@ class Container(containers.DeclarativeContainer):
             "myapi.routers.signal_router",
             "myapi.routers.ticker_router",
             "myapi.routers.news_router",
+            "myapi.routers.auth_router",
         ]
     )
 

--- a/myapi/main.py
+++ b/myapi/main.py
@@ -8,7 +8,7 @@ from starlette.middleware.cors import CORSMiddleware
 
 from myapi import containers
 from myapi.exceptions.index import ServiceException
-from myapi.routers import news_router, signal_router, ticker_router
+from myapi.routers import auth_router, news_router, signal_router, ticker_router
 from myapi.utils.config import init_logging
 
 
@@ -95,4 +95,5 @@ def hello():
 app.include_router(signal_router.router)
 app.include_router(ticker_router.router)
 app.include_router(news_router.router)
+app.include_router(auth_router.router)
 handler = Mangum(app)

--- a/myapi/routers/auth_router.py
+++ b/myapi/routers/auth_router.py
@@ -1,0 +1,29 @@
+from datetime import timedelta
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+
+from myapi.utils.auth import create_access_token
+from myapi.utils.config import get_settings
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+security = HTTPBasic()
+
+
+@router.post("/token")
+def generate_token(credentials: HTTPBasicCredentials = Depends(security)):
+    """Generate a JWT access token using basic auth credentials."""
+    settings = get_settings()
+
+    if (
+        credentials.username != settings.AUTH_USERNAME
+        or credentials.password != settings.AUTH_PASSWORD
+    ):
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+
+    access_token = create_access_token(
+        {"sub": credentials.username},
+        expires_delta=timedelta(minutes=settings.JWT_EXPIRE_MINUTES),
+    )
+    return {"access_token": access_token, "token_type": "bearer"}

--- a/myapi/routers/news_router.py
+++ b/myapi/routers/news_router.py
@@ -3,6 +3,8 @@ from typing import Literal, Optional
 
 from myapi.utils.date_utils import validate_date
 from fastapi import APIRouter, Depends
+
+from myapi.utils.auth import verify_bearer_token
 from dependency_injector.wiring import inject, Provide
 
 from myapi.containers import Container
@@ -51,7 +53,11 @@ def news_recommendations(
     }
 
 
-@router.get("/summary", response_model=WebSearchMarketResponse)
+@router.get(
+    "/summary",
+    response_model=WebSearchMarketResponse,
+    dependencies=[Depends(verify_bearer_token)],
+)
 @inject
 def news_summary(
     signal_service: SignalService = Depends(Provide[Container.services.signal_service]),

--- a/myapi/routers/signal_router.py
+++ b/myapi/routers/signal_router.py
@@ -4,6 +4,8 @@ import logging
 from typing import List, Literal, Optional
 from venv import logger
 from fastapi import APIRouter, Depends
+
+from myapi.utils.auth import verify_bearer_token
 from datetime import date, timedelta
 
 from myapi.utils.date_utils import validate_date
@@ -40,7 +42,11 @@ from myapi.utils.utils import (
 )
 
 
-router = APIRouter(prefix="/signals", tags=["signals"])
+router = APIRouter(
+    prefix="/signals",
+    tags=["signals"],
+    dependencies=[Depends(verify_bearer_token)],
+)
 
 logger = logging.getLogger(__name__)
 

--- a/myapi/routers/ticker_router.py
+++ b/myapi/routers/ticker_router.py
@@ -1,5 +1,7 @@
 import datetime
 from fastapi import APIRouter, Depends, HTTPException, Query
+
+from myapi.utils.auth import verify_bearer_token
 from typing import List, Literal, Optional
 from datetime import date, timedelta
 
@@ -176,7 +178,7 @@ async def get_latest_tickers_with_changes(
         )
 
 
-@router.post("/update")
+@router.post("/update", dependencies=[Depends(verify_bearer_token)])
 @inject
 def update_ticker_informations(
     request: UpdateTickerRequest,

--- a/myapi/utils/auth.py
+++ b/myapi/utils/auth.py
@@ -1,0 +1,51 @@
+"""Utilities for JWT based authentication."""
+
+from datetime import datetime, timedelta
+from typing import Any, Dict
+
+import jwt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+
+from myapi.utils.config import get_settings
+
+security = HTTPBearer(auto_error=False)
+
+
+def create_access_token(data: Dict[str, Any], expires_delta: timedelta | None = None) -> str:
+    """Create a signed JWT access token."""
+    settings = get_settings()
+
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=settings.JWT_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+
+    return jwt.encode(to_encode, settings.JWT_SECRET_KEY, algorithm=settings.JWT_ALGORITHM)
+
+
+def verify_bearer_token(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> Dict[str, Any]:
+    """Validate JWT bearer token provided in the Authorization header."""
+    if credentials is None or credentials.scheme.lower() != "bearer":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid or missing authentication credentials",
+        )
+
+    token = credentials.credentials
+    settings = get_settings()
+
+    try:
+        payload = jwt.decode(
+            token,
+            settings.JWT_SECRET_KEY,
+            algorithms=[settings.JWT_ALGORITHM],
+        )
+    except jwt.PyJWTError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid or expired token",
+        )
+
+    return payload

--- a/myapi/utils/config.py
+++ b/myapi/utils/config.py
@@ -47,6 +47,13 @@ class Settings(BaseSettings):
     DISCORD_WEBHOOK_URL: str = ""
     PERPLEXITY_API_KEY: str = ""
 
+    # JWT authentication settings
+    AUTH_USERNAME: str = "admin"
+    AUTH_PASSWORD: str = "password"
+    JWT_SECRET_KEY: str = "change_me"
+    JWT_ALGORITHM: str = "HS256"
+    JWT_EXPIRE_MINUTES: int = 60
+
     database_engine: str = ""
     database_username: str = ""
     database_password: str = ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ pandas_datareader==0.10.0
 cloudscraper==1.2.71
 pdfplumber==0.11.6
 google-genai
+PyJWT==2.8.0


### PR DESCRIPTION
## Summary
- add token settings
- create auth utility with HTTPBearer
- protect news summary, ticker update and all signal routes
- add JWT auth with token issuance

## Testing
- `python -m py_compile myapi/utils/auth.py myapi/routers/auth_router.py myapi/main.py myapi/containers.py myapi/utils/config.py myapi/routers/news_router.py myapi/routers/ticker_router.py myapi/routers/signal_router.py`
- `pip install -q -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6858b7c10c5c8328839069f7a0d834b3