### PR TITLE
Add Nova Lite integration via Bedrock

### DIFF
--- a/myapi/domain/ai/ai_schema.py
+++ b/myapi/domain/ai/ai_schema.py
@@ -78,6 +78,7 @@ class ChatModel(str, Enum):
     GPT_3_5_TURBO_1106 = "gpt-3.5-turbo-1106"
     GPT_3_5_TURBO_0125 = "gpt-3.5-turbo-0125"
     GPT_3_5_TURBO_16K_0613 = "gpt-3.5-turbo-16k-0613"
+    NOVA_LITE = "nova-lite"
     O4_MINI = "o4-mini-2025-04-16"
     O4_MINI_2024_11_20 = "o4-mini-2025-04-16"
     GPT_4_1_MINI = "gpt-4.1-mini"

--- a/myapi/domain/signal/signal_schema.py
+++ b/myapi/domain/signal/signal_schema.py
@@ -394,7 +394,7 @@ class GenerateSignalResultRequest(BaseModel):
     Response schema for the generate signal result endpoint.
     """
 
-    ai: Literal["OPENAI", "GOOGLE"] = "OPENAI"  # Store the AI model used for the signal
+    ai: Literal["OPENAI", "GOOGLE", "NOVA"] = "OPENAI"  # Store the AI model used for the signal
     data: SignalPromptData
     summary: str
     prompt: str

--- a/myapi/routers/signal_router.py
+++ b/myapi/routers/signal_router.py
@@ -112,6 +112,9 @@ def generate_signal_result(
                 chat_model=ChatModel.O4_MINI,
             )
 
+        if request.ai == "NOVA":
+            result = ai_service.nova_lite_completion(prompt=request.prompt)
+
         if not isinstance(result, SignalPromptResponse):
             return result
 
@@ -242,7 +245,7 @@ def llm_query(
 
     prompt = signal_service.generate_prompt(data=req, report_summary=summary)
 
-    google_result, openai_result = None, None
+    google_result, openai_result, nova_result = None, None, None
 
     try:
         body = GenerateSignalResultRequest(
@@ -295,7 +298,32 @@ def llm_query(
         logger.error(f"Error generating OpenAI signal result: {e}")
         openai_result = None
 
-    return [google_result, openai_result]
+    try:
+        body = GenerateSignalResultRequest(
+            data=req,
+            summary=summary or "No summary available",
+            prompt=prompt,
+            ai="NOVA",  # Request using Nova Lite
+        )
+        nova_result = aws_service.generate_queue_message_http(
+            body=body.model_dump_json(),
+            path="signals/generate-signal-reult",
+            method="POST",
+            query_string_parameters={},
+            auth_token=settings.auth_token,
+        )
+        aws_service.send_sqs_fifo_message(
+            queue_url="https://sqs.ap-northeast-2.amazonaws.com/849441246713/crypto.fifo",
+            message_body=json.dumps(nova_result),
+            message_group_id="nova",
+            message_deduplication_id=req.ticker + "nova" + str(date.today()),
+        )
+
+    except Exception as e:
+        logger.error(f"Error generating Nova signal result: {e}")
+        nova_result = None
+
+    return [google_result, openai_result, nova_result]
 
 
 @router.post(

--- a/myapi/services/ai_service.py
+++ b/myapi/services/ai_service.py
@@ -22,6 +22,8 @@ class AIService:
         self.gemini_api_key = settings.GEMINI_API_KEY
         self.huggingface_api_key = settings.HUGGINGFACE_API_KEY
         self.perplexity_api_key = settings.PERPLEXITY_API_KEY
+        self.bedrock_api_key = settings.BEDROCK_API_KEY
+        self.bedrock_base_url = settings.BEDROCK_BASE_URL
 
     def perplexity_completion(
         self,
@@ -94,6 +96,21 @@ class AIService:
         )
 
         return completion.choices[0].message
+
+    def nova_lite_completion(self, prompt: str):
+        """Call AWS Bedrock Nova Lite model using OpenAI SDK style."""
+        try:
+            client = openai.OpenAI(
+                base_url=self.bedrock_base_url,
+                api_key=self.bedrock_api_key,
+            )
+            completion = client.chat.completions.create(
+                model="nova-lite",
+                messages=[{"role": "user", "content": prompt}],
+            )
+            return completion.choices[0].message
+        except Exception as e:
+            raise HTTPException(status_code=503, detail=f"Bedrock service error: {e}")
 
     def gemini_search_grounding(
         self,

--- a/myapi/utils/config.py
+++ b/myapi/utils/config.py
@@ -46,6 +46,8 @@ class Settings(BaseSettings):
     FRED_API_KEY: str = ""
     DISCORD_WEBHOOK_URL: str = ""
     PERPLEXITY_API_KEY: str = ""
+    BEDROCK_API_KEY: str = ""
+    BEDROCK_BASE_URL: str = ""
 
     # JWT authentication settings
     AUTH_USERNAME: str = "admin"


### PR DESCRIPTION
## Summary
- support AWS Bedrock Nova Lite model
- add nova option in signal generation API
- call Nova Lite using OpenAI client

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bbab14e5c83289adb4fad3977f90c