### PR TITLE
Add web search schema and Perplexity sector API

### DIFF
--- a/myapi/domain/news/__init__.py
+++ b/myapi/domain/news/__init__.py
@@ -1,8 +1,15 @@
-from .news_schema import WebSearchMarketItem, WebSearchMarketResponse
+from .news_schema import (
+    WebSearchMarketItem,
+    WebSearchMarketResponse,
+    WebSearchResultSchema,
+    SectorMomentumResponse,
+)
 from .news_models import WebSearchResult
 
 __all__ = [
     "WebSearchMarketItem",
     "WebSearchMarketResponse",
+    "WebSearchResultSchema",
+    "SectorMomentumResponse",
     "WebSearchResult",
 ]

--- a/myapi/domain/news/news_schema.py
+++ b/myapi/domain/news/news_schema.py
@@ -35,3 +35,53 @@ class MarketForecastSchema(BaseModel):
     reason: str
     up_percentage: Optional[float] = None  # e.g., '70'
     created_at: Optional[str] = None  # ISO format string for datetime
+
+
+class WebSearchResultSchema(BaseModel):
+    id: Optional[int] = None
+    result_type: str
+    ticker: Optional[str] = None
+    date_yyyymmdd: str
+    headline: Optional[str] = None
+    summary: Optional[str] = None
+    detail_description: Optional[str] = None
+    recommendation: Optional[str] = None
+    created_at: Optional[str] = None
+
+
+class KeyNewsSchema(BaseModel):
+    headline: str
+    source: str
+    summary: str
+
+
+class StockMomentumSchema(BaseModel):
+    ticker: str
+    name: str
+    pre_market_change: str
+    key_news: KeyNewsSchema
+    short_term_strategy: str
+
+
+class SectorThemeSchema(BaseModel):
+    key_theme: str
+    stocks: List[StockMomentumSchema]
+
+
+class MomentumSectorSchema(BaseModel):
+    sector_ranking: int
+    sector: str
+    reason: str
+    risk_factor: str
+    themes: List[SectorThemeSchema]
+
+
+class MarketOverviewSchema(BaseModel):
+    summary: str
+    major_catalysts: List[str]
+
+
+class SectorMomentumResponse(BaseModel):
+    analysis_date_est: str
+    market_overview: MarketOverviewSchema
+    top_momentum_sectors: List[MomentumSectorSchema]

--- a/myapi/services/signal_service.py
+++ b/myapi/services/signal_service.py
@@ -1371,16 +1371,7 @@ class SignalService:
             result.append(
                 {
                     "ticker": ticker,
-                    "news": [
-                        {
-                            "date": it.date_yyyymmdd,
-                            "headline": it.headline,
-                            "summary": it.summary,
-                            "detail_description": it.detail_description,
-                            "recommendation": it.recommendation,
-                        }
-                        for it in items
-                    ],
+                    "news": [it.model_dump() for it in items],
                 }
             )
         return result

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package

--- a/tests/test_web_search_repository.py
+++ b/tests/test_web_search_repository.py
@@ -1,0 +1,72 @@
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+import os
+
+os.environ.setdefault("DATABASE_ENGINE", "postgresql+psycopg2")
+os.environ.setdefault("DATABASE_USERNAME", "")
+os.environ.setdefault("DATABASE_PASSWORD", "")
+os.environ.setdefault("DATABASE_HOST", "localhost")
+os.environ.setdefault("DATABASE_PORT", "5432")
+os.environ.setdefault("DATABASE_DBNAME", "test")
+os.environ.setdefault("DATABASE_SCHEMA", "crypto")
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Integer,
+    String,
+    func,
+    MetaData,
+)
+from sqlalchemy.orm import declarative_base
+from myapi.repositories import web_search_repository
+from myapi.repositories.web_search_repository import WebSearchResultRepository
+
+TestBase = declarative_base(metadata=MetaData(schema="crypto"))
+
+
+class TestWebSearchResult(TestBase):
+    __tablename__ = "web_search_results"
+    __table_args__ = {"schema": "crypto"}
+
+    id = Column(Integer, primary_key=True, index=True)
+    result_type = Column(String, nullable=False)
+    ticker = Column(String, nullable=True)
+    date_yyyymmdd = Column(String, nullable=False)
+    headline = Column(String, nullable=True)
+    summary = Column(String, nullable=True)
+    detail_description = Column(String, nullable=True)
+    recommendation = Column(String, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+web_search_repository.WebSearchResult = TestWebSearchResult
+
+
+def setup_session():
+    engine = create_engine("sqlite:///:memory:")
+    with engine.connect() as conn:
+        conn.execute(text("ATTACH DATABASE ':memory:' AS crypto"))
+    TestBase.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+def test_get_search_results():
+    session = setup_session()
+    repo = WebSearchResultRepository(session)
+    repo.bulk_create([
+        TestWebSearchResult(
+            result_type="ticker",
+            ticker="AAPL",
+            date_yyyymmdd="2024-01-01",
+            headline="headline",
+            summary="summary",
+            detail_description="detail",
+            recommendation="Buy",
+        )
+    ])
+
+    results = repo.get_search_results(result_type="ticker", ticker="AAPL")
+    assert len(results) == 1
+    assert results[0].ticker == "AAPL"


### PR DESCRIPTION
## Summary
- introduce `WebSearchResultSchema` and momentum-related response models
- convert repository/service/router to use new schemas
- add sector momentum analysis via Perplexity API
- clean up stray requirements file
- include an initial repository unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68672b9a8bbc8328ae3e85763ea9897a